### PR TITLE
added vhost option & configs to target env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ This is the contents of the published config file:
 <?php
 
 return [
-    'host' => 'rabbitmq',
-    'port' => '5672',
-    'user' => 'guest',
-    'password' => 'guest',
+    'host' => env('RABBITMQ_HOST', '127.0.0.1'),
+    'port' => env('RABBITMQ_PORT', 5672),
+    'user' => env('RABBITMQ_USER', 'guest'),
+    'password' => env('RABBITMQ_PASSWORD', 'guest'),
+    'vhost' => env('RABBITMQ_VHOST', '/'),
 
     'consumers' => [
 //        [

--- a/config/rabbitmq.php
+++ b/config/rabbitmq.php
@@ -1,11 +1,12 @@
 <?php
 
 return [
-    'host' => 'rabbitmq',
-    'port' => '5672',
-    'user' => 'guest',
-    'password' => 'guest',
-
+    'host' => env('RABBITMQ_HOST', '127.0.0.1'),
+    'port' => env('RABBITMQ_PORT', 5672),
+    'user' => env('RABBITMQ_USER', 'guest'),
+    'password' => env('RABBITMQ_PASSWORD', 'guest'),
+    'vhost' => env('RABBITMQ_VHOST', '/'),
+    
     'consumers' => [
 //        [
 //            'event' => '\App\Events\MyEvent',

--- a/src/RabbitMQ.php
+++ b/src/RabbitMQ.php
@@ -17,7 +17,8 @@ class RabbitMQ
             config('rabbitmq.host'),
             config('rabbitmq.port'),
             config('rabbitmq.user'),
-            config('rabbitmq.password')
+            config('rabbitmq.password'),
+            config('rabbitmq.vhost')
         );
 
         $this->channel = $this->connection->channel();


### PR DESCRIPTION
`vhost` is not always `/` for instance in cloudamqp.com the `vhost` is always same as the `user` but never `/` and there is no way for the developers to specify that in this package so I added that and its working.